### PR TITLE
ArcGIS for Desktop not able to show data

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -3,11 +3,11 @@ String.prototype.bool = function() {
 };
 
 function MergeRecursiveCopy(obj1, obj2) {
-	var r = {};
-	for (var i=0; i<arguments.length; i++) {
-		r = MergeRecursive(r, arguments[i]);
-	}
-	return r;
+  var r = {};
+  for (var i=0; i<arguments.length; i++) {
+    r = MergeRecursive(r, arguments[i]);
+  }
+  return r;
 }
 
 function MergeRecursive(obj1, obj2) {
@@ -34,56 +34,96 @@ function MergeRecursive(obj1, obj2) {
 }
 
 Query = function(request) {
-	// See http://resources.arcgis.com/en/help/arcgis-rest-api/#/Query_Feature_Service_Layer/02r3000000r1000000/
-	this.where = request.param("where");
-	var _objectIds = request.param("objectIds");
-	if (_objectIds) {
-		_objectIds = JSON.parse("[" + _objectIds + "]");
-	}
-	this.objectIds = _objectIds;
-	this.geometry = request.param("geometry"); // Not used
-	if (this.geometry) {
-		this.geometry = JSON.parse(this.geometry);
-	}
-	this.geometryType = request.param("geometryType"); // Not used
+  // See http://resources.arcgis.com/en/help/arcgis-rest-api/#/Query_Feature_Service_Layer/02r3000000r1000000/
+  this.where = request.param("where");
+  var _objectIds = request.param("objectIds");
+  if (_objectIds) {
+    _objectIds = JSON.parse("[" + _objectIds + "]");
+  }
+  this.objectIds = _objectIds;
+  
+  function parseSR(sr) {
+    if (sr) {
+      var tempSR = parseInt(sr);
+      if(isNaN(tempSR))
+      {
+        sr = JSON.parse(sr);
+        sr = sr.hasOwnProperty("latestWkid")?sr.latestWkid:sr.wkid;
+      } else {
+        sr = tempSR;
+      }
+    }
+    return sr;
+  }
 
-	var _inSR = request.param("inSR");
-	if (_inSR) { _inSR = parseInt(_inSR); }
-	this.inSR = _inSR; // Not used
+  this.inSR = parseSR(request.param("inSR"));
+  this.outSR = parseSR(request.param("outSR")) || 4326;
 
-	this.spatialRel = request.param("spatialRel"); // Not used
-	this.relationParam = request.param("relationParam"); // Not used
-	this.time = request.param("time"); // Not used
-	
-	var _outFields = (request.param("outFields") || "*");
-	if (_outFields !== "*") {
-		_outFields = _outFields.split(",");
-	}
-	this.outFields = _outFields; // Not used
-	
-	this.returnGeometry = (request.param("returnGeometry") || "false").bool(); // Not used
-	this.returnIdsOnly = (request.param("returnIdsOnly") || "false").bool();
-	this.returnCountOnly = (request.param("returnCountOnly") || "false").bool();
-	
-	var _outSR = request.param("outSR");
-	if (_outSR) { _outSR = parseInt(_outSR); }	
-	this.outSR = _outSR || 4326;
-	
-	this.rawParams = MergeRecursiveCopy(request.params, request.query, request.body);
+  this.geometry = request.param("geometry"); // Not used
+  this.geometryType = request.param("geometryType"); // Not used
 
-	this.format = (request.param("f") || "json").toLowerCase();
-	this.generatedFormat = "json";
-	
-	// The following FeatureService Layer Query Parameters properties are currently ignored:
-	// maxAllowableOffset
-	// geometryPrecision
-	// gdbVersion
-	// returnDistinctValues
-	// orderByFields
-	// groupByFieldsForStatistics
-	// outStatistics
-	// returnZ
-	// returnM
+  if (this.geometry) {
+    // The geometry could be a json geometry, or it could be an
+    // array of coordinates for an envelope (or a point).
+    try {
+      this.geometry = JSON.parse(this.geometry);
+    } catch (ex) {
+      debugger;
+      var coordArray = this.geometry.split(",").map(function(item) {
+        return parseFloat(item);
+      });
+      if (this.geometryType === "esriGeometryEnvelope" && coordArray.length == 4) {
+        this.geometry = {
+          xmin: coordArray[0],
+          ymin: coordArray[1],
+          xmax: coordArray[2],
+          ymax: coordArray[3],
+          spatialReference: { wkid: this.inSR }
+        };
+      } else if (this.geometryType === "esriGeometryPoint" && coordArray.length == 2) {
+        this.geometry = {
+          x: coordArray[0],
+          y: coordArray[1],
+          spatialReference: { wkid: this.inSR }
+        };
+      } else {
+        console.log(ex);
+        console.log("Unexpected geometry type for simple geometry: " + this.geometryType);
+        console.log(this.geometry);
+        throw ex;
+      }
+    }
+  }
+
+  this.spatialRel = request.param("spatialRel"); // Not used
+  this.relationParam = request.param("relationParam"); // Not used
+  this.time = request.param("time"); // Not used
+  
+  var _outFields = (request.param("outFields") || "*");
+  if (_outFields !== "*") {
+    _outFields = _outFields.split(",");
+  }
+  this.outFields = _outFields; // Not used
+  
+  this.returnGeometry = (request.param("returnGeometry") || "false").bool(); // Not used
+  this.returnIdsOnly = (request.param("returnIdsOnly") || "false").bool();
+  this.returnCountOnly = (request.param("returnCountOnly") || "false").bool();
+  
+  this.rawParams = MergeRecursiveCopy(request.params, request.query, request.body);
+
+  this.format = (request.param("f") || "json").toLowerCase();
+  this.generatedFormat = "json";
+  
+  // The following FeatureService Layer Query Parameters properties are currently ignored:
+  // maxAllowableOffset
+  // geometryPrecision
+  // gdbVersion
+  // returnDistinctValues
+  // orderByFields
+  // groupByFieldsForStatistics
+  // outStatistics
+  // returnZ
+  // returnM
 };
 
 exports.Query = Query;


### PR DESCRIPTION
The geometry being passed in by ArcGIS for desktop was of the simplified coordinate array format, and not a JSON geometry. Note, this is entirely legitimate, as per the specs: http://services.arcgis.com/help/index.html?fsquery.html
