### PR TITLE
Fix for symbology for "No Bikes". Not apparent in JS API, but shows up i...

### DIFF
--- a/samples/citybikes/resources/templates/layerDefinition-drawingInfo.json
+++ b/samples/citybikes/resources/templates/layerDefinition-drawingInfo.json
@@ -60,7 +60,7 @@
 		}, {
 			"value": "No bikes",
 			"symbol": {
-				"color": [0, 0, 128, 128],
+				"color": [240, 128, 128, 128],
 				"size": 3,
 				"angle": 0,
 				"xoffset": 0,
@@ -68,7 +68,7 @@
 				"type": "esriSMS",
 				"style": "esriSMSX",
 				"outline": {
-					"color": [240, 128, 128, 255],
+					"color": [0, 0, 0, 0],
 					"width": 1,
 					"type": "esriSLS",
 					"style": "esriSLSSolid"


### PR DESCRIPTION
...n the Runtimes.
