### PR TITLE
Swap the outline and the fill colors for the small X symbol for "No Bikes"

### DIFF
--- a/samples/citybikes/resources/templates/layerDefinition-drawingInfo.json
+++ b/samples/citybikes/resources/templates/layerDefinition-drawingInfo.json
@@ -60,7 +60,7 @@
 		}, {
 			"value": "No bikes",
 			"symbol": {
-				"color": [240, 128, 128, 128],
+				"color": [0, 0, 0, 0],
 				"size": 3,
 				"angle": 0,
 				"xoffset": 0,
@@ -68,7 +68,7 @@
 				"type": "esriSMS",
 				"style": "esriSMSX",
 				"outline": {
-					"color": [0, 0, 0, 0],
+					"color": [240, 128, 128, 128],
 					"width": 1,
 					"type": "esriSLS",
 					"style": "esriSLSSolid"


### PR DESCRIPTION
I swear I had this the right way around before. In fact, I had to change it. I wonder whether something changed in the JS API...
