### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ View a [live demo](http://geonode.geeknixta.com).
 
 ![Sample Image](docs/citibike-svc.png)
 
-##Introduction
+## Introduction
 The application handles ArcGIS REST API requests to custom "data providers", and returns their output in ArcGIS JSON format.
 
 Here are two sample "data providers":
@@ -40,19 +40,19 @@ By using the Esri [Terraformer](https://github.com/esri/terraformer) library's `
 ## Requirements
 * [node.js](http://nodejs.org)
 
-##Installation
+## Installation
 1. Clone the repo and run `npm update` in the repo folder
 2. Run the node server with `node index`
 3. Browse to [http://localhost:1337](http://localhost:1337)
 
-##Sample Data Providers
-###Citybikes
+## Sample Data Providers
+### Citybikes
 The Citybikes sample data provider makes use of the [awesome API](http://api.citybik.es) at [CityBik.es](http://citybik.es) providing bike share data (almost) globally. This sample Data Provider adapts the data into Geoservices format output. The root REST endpoint 
 for the CityBikes data provider can be found live here (this is where you might point ArcCatalog): http://geonode.geeknixta.com/citybikes/rest/services
-###GeoHub
+### GeoHub
 Making use of the [GeoHub repo](https://github.com/chelm/geohub), this sample provider allows a client to request geoJSON files from either a GitHub repository ([example](https://github.com/chelm/grunt-geo/blob/master/forks.geojson)) or from a GitHub gist ([example](https://gist.github.com/chelm/6178185)). This sample uses the `dataproviderbase` GeoStore cache framework. For more details, see the [GeoHub Plugin Readme](samples/geohub/README.md).
 
-##Known Limitations
+## Known Limitations
 * Only a limited subset of the [Geoservices REST Specification](http://resources.arcgis.com/en/help/arcgis-rest-api/) is implemented.
 	* [`Server Info`](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Server_Info/02r300000116000000/)
 	* [`Catalog`](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Catalog/02r3000000tn000000/)

--- a/samples/geohub/README.md
+++ b/samples/geohub/README.md
@@ -5,7 +5,7 @@ This is a sample Data Provider for the [node-geoservices-adaptor](../..).
 
 It provides access to geoJSON files stored in GitHub by providing a wrapper around [GeoHub](https://github.com/chelm/geohub).
 
-##GitHub Repository
+## GitHub Repository
 To reference a geoJSON file from a GitHub repository, use the following REST URL structure:
 
 	/geohub/rest/services/repo+<GitHub Username>+<Repo Name>+<File Name>/FeatureServer/0
@@ -21,7 +21,7 @@ Below is a sample URL that you can add directly to an ArcGIS Online map or consu
 * Access `forks.geojson` in chelm's grunt-geo repo: http://geonode.geeknixta.com/geohub/rest/services/repo+chelm+grunt-geo+forks/FeatureServer/0
 * Access `samples/bower.geojson` in chelm's grunt-geo repo: http://geonode.geeknixta.com/geohub/rest/services/repo+chelm+grunt-geo+samples%2Fbower/FeatureServer/0
 
-##GitHub Gist
+## GitHub Gist
 
 To reference a geoJSON file from a GitHub Gist, use the following REST URL structure:
 
@@ -37,8 +37,8 @@ Below are some sample URLs that you can add directly to an ArcGIS Online map or 
 * Access the first geoJSON file in gist `6178185`: http://geonode.geeknixta.com/geohub/rest/services/gist+6178185/FeatureServer/0
 * Access the second geoJSON file in gist `6178185`: http://geonode.geeknixta.com/geohub/rest/services/gist+6178185/FeatureServer/1
 
-##Notes
-###geoJSON containing multiple geometry types
+## Notes
+### geoJSON containing multiple geometry types
 
 An ArcGIS Feature Layer can only provide a single type of Esri Geometry. However, geoJSON files may contain any combination of [Geometry Types](http://www.geojson.org/geojson-spec.html#geometry-objects). The GeoHub Data Provider defaults to outputting only geometries matching the type of the first geometry encountered in the geoJSON file. In the case where the geoJSON includes multiple Geometry Types and the first geometry in the geoJSON file is not the type you want to provide, add the optional `+<GeometryType>` specifier like this:
 
@@ -59,12 +59,12 @@ Where `<GeometryType>` is a valid geoJSON Geometry Type as specified by the [geo
 
 Below are some sample URLs that you can add directly to an ArcGIS Online map or consume with one of the ArcGIS APIs:
 
-#####Repository:
+##### Repository:
 * Access `forks.geojson` in chelm's grunt-geo repo, filtering by geometry type `LineString`: http://geonode.geeknixta.com/geohub/rest/services/repo+chelm+grunt-geo+forks+LineString/FeatureServer/0
 * Access `samples/bower.geojson` in chelm's grunt-geo repo, filtering by geometry type `LineString`: http://geonode.geeknixta.com/geohub/rest/services/repo+chelm+grunt-geo+samples%2Fbower+LineString/FeatureServer/0
 
-#####Gist:
+##### Gist:
 * Access the second geoJSON file in gist `6178185` and view only `Point` geometries: http://geonode.geeknixta.com/geohub/rest/services/gist+6178185+Point/FeatureServer/1
 
-###GeoHub
+### GeoHub
 This adaptor makes use of [GeoHub](https://github.com/chelm/geohub).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
